### PR TITLE
윈도에서 스크롤바가 두 개 보이는 문제 수정

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -18,7 +18,7 @@ div.highlighter-rouge + div {
  * Non-text blocks such as codes, outputs and tables
  */
 body > div {
-  overflow-x: scroll;
+  overflow-x: auto;
   padding: 0.5em 1em 0.5em calc(1em - 3px);
   margin: 0.5em -1em 0.5em;
   line-height: 1.8;


### PR DESCRIPTION
스크롤바 두 개 보이는 문제는 #65 에서 수정되었고, 남은 문제인 윈도에서 스크롤할 내용이 없더라도 스크롤바가 항상 보이던 문제를 수정하였습니다. (`overflow-x: scroll`을 `overflow-x: auto`)

Close #64 